### PR TITLE
Fixed invalid `CheckoutOpenBaseOptions['customData']` type

### DIFF
--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -78,8 +78,21 @@ interface CheckoutOpenOptionsWithDiscountCode {
 interface CheckoutOpenBaseOptions {
   settings?: CheckoutSettings;
   customer?: CheckoutCustomer;
-  customData?: Record<string, string | number | boolean>;
+  customData?: Record<string, Encodable>;
 }
+
+/*
+ * While JSON.stringify encodes Dates to ISO string,
+ * we do not consider Date as Encodable,
+ * because it does not decode to Date type automatically (remains ISO string)
+ *
+ * It is better to leave for developers to decide to encode Date,
+ * otherwise they can get unexpected behavior
+ */
+type EncodablePrimitive = string | number | boolean | null;
+type EncodableMap = Record<string, Encodable>;
+type EncodableArray = Array<Encodable>;
+type Encodable = EncodablePrimitive | EncodableMap | EncodableArray;
 
 type CheckoutOpenOptionsWithLineItems = CheckoutOpenOptionsWithItems | CheckoutOpenOptionsWithTransactionId;
 type CheckoutOpenOptionsWithDiscount = CheckoutOpenOptionsWithDiscountId | CheckoutOpenOptionsWithDiscountCode;


### PR DESCRIPTION
Hi! I've made this before I've read your contribution guidelines, so pardon my audacity.

Your `CheckoutOpenBaseOptions['customData']` type is somewhat considerable, but it does not display the real interface of this hashmap. 
Since you decided to be specific about your custom data interface, it should either be expanded to match the reality or should be washed out like `object`. 

After a bit of testing upon your sandbox server, I'm pretty sure, that your API accepts any encodable data, while the fundamental type is JSON-object. 
That means not only string or number like before, but also encodable objects, encodable arrays and nulls.

Consider this custom data:
```js
Paddle.Checkout.open({
  items: [{ quantity: 1, priceId: "PRICE_ID" }],
  customData: {
    array: [1, 2, 3, [4, 5, 6]],
    bool: true,
    date: new Date(), // does not decode back, default JSON.parse behavior, thus excluded from type
    null: null,
    number: 500,
    object: { foo: "bar", baz: { null: null } },
    string: "Hello, GitHub!",
  },
});
```

Everything here is forwarded to "checkout.completed" event successfully, except date (which is expected)

![CleanShot 2023-11-07 at 16 32 42@2x](https://github.com/PaddleHQ/paddle-js-wrapper/assets/16625670/38b5bef5-6be3-444f-b7c6-392fbf322b01)

Would you consider updating your type?