### PR TITLE
Updated Example to use token instead of seller ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export function Checkout() {
 
   // Download and initialize Paddle instance from CDN
   useEffect(() => {
-    initializePaddle({ environment: 'ENVIRONMENT_GOES_HERE', seller: 'SELLER_ID_GOES_HERE' }).then(
+    initializePaddle({ environment: 'ENVIRONMENT_GOES_HERE', token: 'AUTH_TOKEN_GOES_HERE' }).then(
       (paddleInstance: Paddle | undefined) => {
         if (paddleInstance) {
           setPaddle(paddleInstance);


### PR DESCRIPTION
Updating the react example in Readme to use `token` instead of `seller` as  client side tokens are the new preferred way of identification.
The `token` is not a secret so it is ok to pass from client side code.