### PR TITLE
Updated Example to use token instead of seller ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export function Checkout() {
 
   // Download and initialize Paddle instance from CDN
   useEffect(() => {
-    initializePaddle({ environment: 'ENVIRONMENT_GOES_HERE', seller: 'SELLER_ID_GOES_HERE' }).then(
+    initializePaddle({ environment: 'ENVIRONMENT_GOES_HERE', token: 'AUTH_TOKEN_GOES_HERE' }).then(
       (paddleInstance: Paddle | undefined) => {
         if (paddleInstance) {
           setPaddle(paddleInstance);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Updating the react example in Readme to use token instead of seller as client side tokens are the new preferred way of identification.
The token is not a secret so it is ok to pass from client side code.