### PR TITLE
Removed crossOrigin header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -9,7 +9,6 @@ export function findScript(): HTMLScriptElement | undefined {
 export function injectScript(src: string): HTMLScriptElement {
   const script = document.createElement('script');
   script.src = src;
-  script.crossOrigin = 'anonymous';
 
   const headOrBody = document.head || document.body;
 


### PR DESCRIPTION
Removing the crossOrigin header from the script tag as we noticed some issues with CORS headers in some implementations.