### PR TITLE
Adding `Paddle.Update` feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -26,6 +26,9 @@ const mockedPaddleInstance: Paddle = {
     hide: jest.fn(),
     show: jest.fn(),
   },
+  Initialized: false,
+  Initialize: jest.fn(),
+  Update: jest.fn(),
 };
 
 interface SharedModule {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,11 @@ export async function initializePaddle(options?: InitializePaddleOptions): Promi
         if (environment) {
           paddle.Environment.set(environment);
         }
-        paddle.Setup({
-          ...rest,
-        });
+        if (paddle.Initialized) {
+          paddle.Update({ ...rest });
+        } else {
+          paddle.Initialize({ ...rest });
+        }
       } catch (e) {
         console.warn('Paddle Initialization failed. Please check the inputs', e);
       }

--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -22,12 +22,14 @@ export interface CheckoutSettings {
   allowedPaymentMethods?: AvailablePaymentMethod[];
 }
 
+export interface PaddleSetupPwCustomer {
+  id?: string;
+  email?: string;
+}
+
 interface PaddleSetupBaseOptions {
   pwAuth?: string;
-  pwCustomer?: {
-    id?: string;
-    email?: string;
-  };
+  pwCustomer?: PaddleSetupPwCustomer;
   debug?: boolean;
   eventCallback?: (event: PaddleEventData) => void;
   checkout?: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ import {
   PaddleSetupOptions,
   CheckoutSettings,
   PaddleEventData,
+  PaddleSetupPwCustomer,
 } from './checkout/checkout';
 import { CheckoutCustomer, CheckoutCustomerAddress, CheckoutCustomerBusiness } from './checkout/customer';
 import { PricePreviewItem, PricePreviewParams, PricePreviewResponse } from './price-preview/price-preview';
@@ -47,6 +48,7 @@ export type Environments = 'production' | 'sandbox';
 export type Theme = 'light' | 'dark';
 
 export {
+  PaddleSetupPwCustomer,
   AvailablePaymentMethod,
   CheckoutOpenOptions,
   PaddleSetupOptions,
@@ -84,6 +86,9 @@ export interface Paddle {
   };
   PricePreview: (params: PricePreviewParams) => Promise<PricePreviewResponse>;
   TransactionPreview: (params: TransactionPreviewParams) => Promise<TransactionPreviewResponse>;
+  /**
+    @deprecated. Use `Paddle.Initialize` instead.
+   */
   Setup(options: PaddleSetupOptions): void;
   Spinner: {
     show(): void;
@@ -92,12 +97,15 @@ export interface Paddle {
   Status: {
     libraryVersion: string;
   };
+  Initialized: boolean;
+  Initialize(options: PaddleSetupOptions): void;
+  Update(options: Partial<PaddleSetupOptions>): void;
 }
 
 declare global {
   interface Window {
     // Paddle.JS will be downloaded directly from our CDN and added to global variable
-    Paddle?: Paddle;
+    Paddle?: Paddle | undefined;
   }
 }
 


### PR DESCRIPTION
## 1.0.2 - 2024-02-26

### Added

- Added `paddle.Initialize` function, this is the same as `paddle.Setup`. They are the same now, however we will be diverging them in the future.
- Added `paddle.Update` function. We can call this to update `pwCustomer` or `eventCallback` after initializing Paddle JS
- Added `paddle.Initialized` flag to help identify if PaddleJS is already initialized.

### Deprecated

- Deprecated `paddle.Setup` in favour of `paddle.Initialize` field. 

### Fixes:
#27 & #20 
---