### PR TITLE
Added missing type definition for `Paddle.Checkout.updateCheckout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
 
+## 1.1.1 - 2024-05-28
+
+### Fixed
+
+- Added missing type definition for `Paddle.Checkout.updateCheckout` [function](https://developer.paddle.com/paddlejs/methods/paddle-checkout-updatecheckout?utm_source=dx&utm_medium=paddle-js-wrapper).
+
+--- 
+
 ## 1.1.0 - 2024-05-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -10,6 +10,7 @@ const mockedPaddleInstance: Paddle = {
     close: jest.fn(),
     open: jest.fn(),
     updateItems: jest.fn(),
+    updateCheckout: jest.fn(),
   },
   Environment: {
     set: jest.fn(),

--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -11,6 +11,7 @@ const mockedPaddleInstance: Paddle = {
     close: jest.fn(),
     open: jest.fn(),
     updateItems: jest.fn(),
+    updateCheckout: jest.fn(),
   },
   Environment: {
     set: jest.fn(),

--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -97,3 +97,8 @@ type CheckoutOpenOptionsWithDiscount = CheckoutOpenOptionsWithDiscountId | Check
 export type CheckoutOpenOptions = CheckoutOpenBaseOptions &
   CheckoutOpenOptionsWithLineItems &
   CheckoutOpenOptionsWithDiscount;
+
+export type CheckoutUpdateOptions = CheckoutOpenOptionsWithDiscount & {
+  items: CheckoutOpenLineItem[];
+  customer?: CheckoutCustomer;
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,7 @@ import {
   CheckoutSettings,
   PaddleEventData,
   PaddleSetupPwCustomer,
+  CheckoutUpdateOptions,
 } from './checkout/checkout';
 import { CheckoutCustomer, CheckoutCustomerAddress, CheckoutCustomerBusiness } from './checkout/customer';
 import { PricePreviewItem, PricePreviewParams, PricePreviewResponse } from './price-preview/price-preview';
@@ -54,6 +55,7 @@ export type Theme = 'light' | 'dark';
 export {
   PaddleSetupPwCustomer,
   CheckoutOpenOptions,
+  CheckoutUpdateOptions,
   PaddleSetupOptions,
   CheckoutLineItem,
   CheckoutOpenLineItem,
@@ -76,6 +78,7 @@ export {
 export interface Paddle {
   Checkout: {
     open(input: CheckoutOpenOptions): void;
+    updateCheckout(input: CheckoutUpdateOptions): void;
     updateItems(items: CheckoutLineItem[]): void;
     close(): void;
   };


### PR DESCRIPTION
## 1.1.1 - 2024-05-28

### Fixed

- Added missing type definition for `Paddle.Checkout.updateCheckout` [function](https://developer.paddle.com/paddlejs/methods/paddle-checkout-updatecheckout?utm_source=dx&utm_medium=paddle-js-wrapper).

--- 

Fixes: #36 