### PR TITLE
fix(Types): Added missing `price_name` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.1.1-next.1 - 2024-07-29
+
+### Fixed
+
+- Added missing `price_name` property to checkout events callback.
+
+---
 
 ## 1.1.1-next.0 - 2024-06-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.1.1-next.0",
+  "version": "1.1.1-next.1",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/checkout/events.d.ts
+++ b/types/checkout/events.d.ts
@@ -56,6 +56,7 @@ export enum CheckoutEventsStatus {
   READY = 'ready',
   COMPLETED = 'completed',
   BILLED = 'billed',
+  PAID = 'paid',
   canceled = 'canceled',
   PAST_DUE = 'past_due',
 }
@@ -106,6 +107,7 @@ export interface CheckoutEventsTotals {
 export interface CheckoutEventsItem {
   billing_cycle?: CheckoutEventsTimePeriod;
   price_id: string;
+  price_name?: string | null;
   product: CheckoutEventsItemProduct;
   quantity: number;
   recurring_totals?: CheckoutEventsTotals;


### PR DESCRIPTION
## 1.1.1-next.1 - 2024-07-29

### Fixed

- Added missing `price_name` property to checkout events callback.

---