### PR TITLE
fix(Types): update customData type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.2.2-next.0 - 2024-09-27
+
+### Fixed
+
+- Updated `customData` checkout type to allow nested objects.
+
+---
+
 ## 1.1.1-next.1 - 2024-07-29
 
 ### Fixed
@@ -28,7 +36,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 - Added missing type definition for `Paddle.Checkout.updateCheckout` [function](https://developer.paddle.com/paddlejs/methods/paddle-checkout-updatecheckout?utm_source=dx&utm_medium=paddle-js-wrapper).
 
---- 
+---
 
 ## 1.1.0 - 2024-05-16
 
@@ -36,7 +44,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 - Added changelog.
 
---- 
+---
 
 ## 1.0.3 - 2024-03-14
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.1.1-next.1",
+  "version": "1.2.2-next.0",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -89,7 +89,7 @@ interface CheckoutOpenOptionsWithDiscountCode {
 interface CheckoutOpenBaseOptions {
   settings?: CheckoutSettings;
   customer?: CheckoutCustomer;
-  customData?: Record<string, string | number | boolean>;
+  customData?: Record<string, unknown>;
 }
 
 type CheckoutOpenOptionsWithLineItems = CheckoutOpenOptionsWithItems | CheckoutOpenOptionsWithTransactionId;


### PR DESCRIPTION
## Changes:

Updates the `customData` type to match as is in [shared.ts](https://github.com/PaddleHQ/paddle-js-wrapper/blob/main/types/shared/shared.d.ts#L77)

In `paddle-js-v2` we actually allow any valid object including nested objects so this updates the type to reflect that

```
  if (hasValue(input.customData)) {
    try {
      // When we pass this value using `data-custom-data` html attribute it will be a string. So we are parsing it to check its validity
      const customData = typeof input.customData === 'string' ? JSON.parse(input.customData) : input.customData
      if (isObjectValid(customData)) {
        checkoutProps.customData = JSON.stringify(customData)
      } else {
        throw new Error('Invalid custom data')
      }
    } catch (e) {
      logger.log(INVALID_CUSTOM_DATA, LOG_LEVEL.WARNING, true)
    }
  }
```

## Testing

Tested locally with `pnpm link` 

```
    paddle?.Checkout.open({
      items: [{ priceId: id, quantity: 1 }],
      customData: {
        foo: {
          bar: "baz",
        }
      }
    });
```

![image](https://github.com/user-attachments/assets/8e62a098-6235-49ba-a6d6-2a6d58ea407b)


is now a valid option, but things like:
```
customData: []
or
customData: new Map([["foo", "bar"]]),
or
customData: null
```

remain invalid