### PR TITLE
1.2.3-next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.2.3-next.0 - 2024-09-30
+
+### Fixed
+
+- `Checkout.updateCheckout` `discountId` and `discountCode` can both be `null`.
+
+### Added
+
+- Added `variant` to checkout settings.
+
+---
+
 ## 1.2.2-next.0 - 2024-09-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## 1.2.3-next.0 - 2024-09-30
+## 1.2.3-next.0 - 2024-10-01
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.2.2-next.0",
+  "version": "1.2.3-next.0",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -5,6 +5,7 @@ import {
   DisplayMode,
   Theme,
   AvailablePaymentMethod,
+  Variant,
 } from '../index';
 import { CheckoutCustomer } from './customer';
 
@@ -21,6 +22,7 @@ export interface CheckoutSettings {
   successUrl?: string;
   allowedPaymentMethods?: AvailablePaymentMethod[];
   allowDiscountRemoval?: boolean;
+  variant?: Variant;
 }
 
 export interface PaddleSetupPwCustomer {

--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -80,11 +80,11 @@ interface CheckoutOpenOptionsWithTransactionId {
 }
 interface CheckoutOpenOptionsWithDiscountId {
   discountCode?: never;
-  discountId?: string;
+  discountId?: string | null;
 }
 
 interface CheckoutOpenOptionsWithDiscountCode {
-  discountCode?: string;
+  discountCode?: string | null;
   discountId?: never;
 }
 

--- a/types/shared/shared.d.ts
+++ b/types/shared/shared.d.ts
@@ -3,6 +3,8 @@ import { CurrencyCode } from './currency-code';
 
 export type AvailablePaymentMethod = 'alipay' | 'apple_pay' | 'bancontact' | 'card' | 'google_pay' | 'ideal' | 'paypal';
 
+export type Variant = 'multi-page' | 'one-page';
+
 export type TaxMode = 'account_setting' | 'external' | 'internal';
 
 export type Status = 'active' | 'archived';


### PR DESCRIPTION
## Changes

- Adds optional `variant` checkout setting
- Updates `Checkout.updateCheckout` discount values to be nullable - this was a type mismatch since the checkout can be updated to remove a discount