### PR TITLE
hotfix: fallback to window.Paddle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.3.1 - 2024-10-29
+
+### Fixed
+
+- Fallback to window.Paddle if Billing or Classic cannot be found
+
+---
+
 ## 1.3.0 - 2024-10-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,10 @@ export async function initializePaddle(options?: InitializePaddleOptions): Promi
 
 export function getPaddleInstance(version: Version = DefaultVersion) {
   if (version === Versions.V1) {
-    return window.PaddleBillingV1 as Paddle;
+    return (window.PaddleBillingV1 || window.Paddle) as Paddle;
   } else if (version === Versions.CLASSIC) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return window.PaddleClassic as any;
+    return (window.PaddleClassic || window.Paddle) as any;
   } else {
     console.error('[Paddle] Unknown Paddle Version');
     return;

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -51,8 +51,8 @@ export function loadFromCDN(version: Version): Promise<Paddle | undefined> | und
     }
 
     // Return Paddle instance if it is already initialized
-    if (window[paddleInstanceName]) {
-      resolve(window[paddleInstanceName]);
+    if (window[paddleInstanceName] || window.Paddle) {
+      resolve(window[paddleInstanceName] || window.Paddle);
       return;
     }
 
@@ -66,8 +66,8 @@ export function loadFromCDN(version: Version): Promise<Paddle | undefined> | und
 
       // Wait for `load` event before returning
       script.addEventListener('load', () => {
-        if (window[paddleInstanceName]) {
-          resolve(window[paddleInstanceName]);
+        if (window[paddleInstanceName] || window.Paddle) {
+          resolve(window[paddleInstanceName] || window.Paddle);
         } else {
           reject(new Error('Paddle.js not available'));
         }


### PR DESCRIPTION
Adds a fallback to use `window.Paddle` if the requested version cannot be found