### PR TITLE
fix: add return type to getPaddleInstance type def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.3.2 - 2024-11-06
+
+### Fixed
+
+- Add return type to `getPaddleInstance` type definition
+
+---
+
 ## 1.3.1 - 2024-10-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -127,4 +127,7 @@ export type InitializePaddleOptions = PaddleSetupOptions & {
 };
 
 export function initializePaddle(options?: InitializePaddleOptions): Promise<Paddle | undefined>;
-export function getPaddleInstance(version?: Version);
+export function getPaddleInstance(version: 'v1'): Paddle | undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getPaddleInstance(version: 'classic'): any;
+export function getPaddleInstance(): Paddle | undefined;


### PR DESCRIPTION
Adds return type to `getPaddleInstance` type def