### PR TITLE
[Next] Saved Payment methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.3.2-next.0",
+  "version": "1.3.3-next.0",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -91,7 +91,7 @@ interface CheckoutOpenOptionsWithDiscountCode {
 interface CheckoutOpenOptionsWithCustomer {
   customer?: CheckoutCustomer;
   customerAuthToken?: never;
-  savedPaymentMethodId?: string;
+  savedPaymentMethodId?: never;
 }
 
 interface CheckoutOpenOptionsWithCustomerAuthToken {

--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -88,20 +88,33 @@ interface CheckoutOpenOptionsWithDiscountCode {
   discountId?: never;
 }
 
+interface CheckoutOpenOptionsWithCustomer {
+  customer?: CheckoutCustomer;
+  customerAuthToken?: never;
+  savedPaymentMethodId?: string;
+}
+
+interface CheckoutOpenOptionsWithCustomerAuthToken {
+  customer?: never;
+  customerAuthToken?: string;
+  savedPaymentMethodId?: string;
+}
+
 interface CheckoutOpenBaseOptions {
   settings?: CheckoutSettings;
-  customer?: CheckoutCustomer;
   customData?: Record<string, unknown>;
 }
 
 type CheckoutOpenOptionsWithLineItems = CheckoutOpenOptionsWithItems | CheckoutOpenOptionsWithTransactionId;
 type CheckoutOpenOptionsWithDiscount = CheckoutOpenOptionsWithDiscountId | CheckoutOpenOptionsWithDiscountCode;
+type CheckoutOpenOptionsWithCustomerData = CheckoutOpenOptionsWithCustomer | CheckoutOpenOptionsWithCustomerAuthToken;
 
 export type CheckoutOpenOptions = CheckoutOpenBaseOptions &
   CheckoutOpenOptionsWithLineItems &
-  CheckoutOpenOptionsWithDiscount;
+  CheckoutOpenOptionsWithDiscount &
+  CheckoutOpenOptionsWithCustomerData;
 
-export type CheckoutUpdateOptions = CheckoutOpenOptionsWithDiscount & {
-  items: CheckoutOpenLineItem[];
-  customer?: CheckoutCustomer;
-};
+export type CheckoutUpdateOptions = CheckoutOpenOptionsWithDiscount &
+  CheckoutOpenOptionsWithCustomerData & {
+    items: CheckoutOpenLineItem[];
+  };

--- a/types/shared/shared.d.ts
+++ b/types/shared/shared.d.ts
@@ -1,7 +1,15 @@
 import { CountryCode } from './country-code';
 import { CurrencyCode } from './currency-code';
 
-export type AvailablePaymentMethod = 'alipay' | 'apple_pay' | 'bancontact' | 'card' | 'google_pay' | 'ideal' | 'paypal';
+export type AvailablePaymentMethod =
+  | 'alipay'
+  | 'apple_pay'
+  | 'bancontact'
+  | 'card'
+  | 'google_pay'
+  | 'ideal'
+  | 'paypal'
+  | 'saved_payment_methods';
 
 export type Variant = 'multi-page' | 'one-page';
 


### PR DESCRIPTION
Updates the `Checkout.open` and checkout settings types to include changes related to saved payment methods

Relevant docs: https://developer.paddle.com/changelog/2024/saved-payment-methods#change-fields

## Changes
- `saved_payment_methods` is now an option for `allowedPaymentMethods`
- A `customerAuthToken` can be provided to show saved payment methods (this is mutually exclusive with the `customer` field so `customer` cannot be used with a `customerAuthToken`)
- A `savedPaymentMethodId` can be provided to preselect a saved payment method