### PR TITLE
feat: Add support for `prePaymentFailure` in `Paddle.Retain.demo()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.4.1 - 2025-04-16
+
+### Fixed
+
+- Remove fallback to window.Paddle
+
+---
+
 ## 1.4.0-next.0 - 2025-03-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.4.2-next.0 - 2025-06-18
+
+### Added
+
+- Added support for `prePaymentFailure` in `Paddle.Retain.demo()` function.
+
+---
+
+
 ## 1.4.1 - 2025-04-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.4.0-next.0",
+  "version": "1.4.1",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.4.1",
+  "version": "1.4.2-next.0",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,10 @@ export async function initializePaddle(options?: InitializePaddleOptions): Promi
 
 export function getPaddleInstance(version: Version = DefaultVersion) {
   if (version === Versions.V1) {
-    return (window.PaddleBillingV1 || window.Paddle) as Paddle;
+    return window.PaddleBillingV1 as Paddle;
   } else if (version === Versions.CLASSIC) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (window.PaddleClassic || window.Paddle) as any;
+    return window.PaddleClassic as any;
   } else {
     console.error('[Paddle] Unknown Paddle Version');
     return;

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -51,8 +51,8 @@ export function loadFromCDN(version: Version): Promise<Paddle | undefined> | und
     }
 
     // Return Paddle instance if it is already initialized
-    if (window[paddleInstanceName] || window.Paddle) {
-      resolve(window[paddleInstanceName] || window.Paddle);
+    if (window[paddleInstanceName]) {
+      resolve(window[paddleInstanceName]);
       return;
     }
 
@@ -66,8 +66,8 @@ export function loadFromCDN(version: Version): Promise<Paddle | undefined> | und
 
       // Wait for `load` event before returning
       script.addEventListener('load', () => {
-        if (window[paddleInstanceName] || window.Paddle) {
-          resolve(window[paddleInstanceName] || window.Paddle);
+        if (window[paddleInstanceName]) {
+          resolve(window[paddleInstanceName]);
         } else {
           reject(new Error('Paddle.js not available'));
         }

--- a/types/checkout/retain.d.ts
+++ b/types/checkout/retain.d.ts
@@ -5,7 +5,8 @@ export type RETAIN_DEMO_FEATURE =
   | 'paymentRecoveryInApp'
   | 'termOptimization'
   | 'termOptimizationInApp'
-  | 'cancellationFlow';
+  | 'cancellationFlow'
+  | 'prePaymentFailure';
 
 type RetainCancellationFlowNotShownStatus = 'error';
 


### PR DESCRIPTION
## 1.4.2-next.0 - 2025-06-18

### Added

- Added support for `prePaymentFailure` in `Paddle.Retain.demo()` function.

---


## 1.4.1 - 2025-04-16

### Fixed

- Remove fallback to window.Paddle

---