### PR TITLE
feat: Add support for `prePaymentFailure` in `Paddle.Retain.demo()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## 1.4.2-next.0 - 2025-06-18
+## 1.4.2 - 2025-06-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.4.2-next.0 - 2025-06-18
+
+### Added
+
+- Added support for `prePaymentFailure` in `Paddle.Retain.demo()` function.
+
+---
+
+
 ## 1.4.1 - 2025-04-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.4.1",
+  "version": "1.4.2-next.0",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.4.2-next.0",
+  "version": "1.4.2",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/checkout/retain.d.ts
+++ b/types/checkout/retain.d.ts
@@ -5,7 +5,8 @@ export type RETAIN_DEMO_FEATURE =
   | 'paymentRecoveryInApp'
   | 'termOptimization'
   | 'termOptimizationInApp'
-  | 'cancellationFlow';
+  | 'cancellationFlow'
+  | 'prePaymentFailure';
 
 type RetainCancellationFlowNotShownStatus = 'error';
 


### PR DESCRIPTION
## 1.4.2 - 2025-06-18

### Added

- Added support for `prePaymentFailure` in `Paddle.Retain.demo()` function.

---