### PR TITLE
feat: add new payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.5.1 - 2025-11-11
+
+### Added
+
+- Updated `AvailablePaymentMethod` union to include korean payment methods, BLIK, MB WAY, Pix and UPI.
+
 ## 1.5.0 - 2025-11-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/shared/shared.d.ts
+++ b/types/shared/shared.d.ts
@@ -5,11 +5,20 @@ export type AvailablePaymentMethod =
   | 'alipay'
   | 'apple_pay'
   | 'bancontact'
+  | 'blik'
   | 'card'
   | 'google_pay'
   | 'ideal'
+  | 'kakao_pay'
+  | 'south_korea_local_card'
+  | 'mb_way'
+  | 'naver_pay'
+  | 'payco'
   | 'paypal'
-  | 'saved_payment_methods';
+  | 'pix'
+  | 'samsung_pay'
+  | 'saved_payment_methods'
+  | 'upi';
 
 export type Variant = 'multi-page' | 'one-page';
 


### PR DESCRIPTION
## Details

Updated `AvailablePaymentMethod` to include new payment methods

- blik
- kakao_pay
- south_korea_local_card
- mb_way
- naver_pay
- payco
- pix
- samsung_pay
- upi