### PR TITLE
[APPEX-351] Migrate paddle-js-wrapper to granular NPM token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,4 +60,4 @@ jobs:
             yarn publish:latest
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_PADDLE_JS_WRAPPER }}


### PR DESCRIPTION
This will remove usage of existing `NPM_TOKEN` which is a classic token that will be revoked on 19th November 2025. [1]
The new secret is already provisioned on the repo for Github Actions

[1]: https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/