### PR TITLE
fix: Migrate to granular NPM token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,4 +52,4 @@ jobs:
             yarn publish:latest
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_PADDLE_JS_WRAPPER }}


### PR DESCRIPTION
### Fixed

- Migrate to granular NPM token - ported from https://github.com/PaddleHQ/paddle-js-wrapper/pull/112