### PR TITLE
Add wechat pay support (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.6.2 - 2026-02-02
+
+### Added
+
+- Added `wechat_pay` to `AvailablePaymentMethod` type.
+- Added `WECHAT_PAY` to `CheckoutEventsPaymentMethodTypes` enum.
+
 ## 1.6.1 - 2025-12-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/constants/checkout-events.ts
+++ b/src/constants/checkout-events.ts
@@ -34,6 +34,7 @@ export enum CheckoutEventsPaymentMethodTypes {
   GOOGLE_PAY = 'google-pay',
   IDEAL = 'ideal',
   PAYPAL = 'paypal',
+  WECHAT_PAY = 'wechat-pay',
   WIRE_TRANSFER = 'wire-transfer',
   NONE = 'none',
 }

--- a/types/checkout/events.d.ts
+++ b/types/checkout/events.d.ts
@@ -36,6 +36,7 @@ export enum CheckoutEventsPaymentMethodTypes {
   GOOGLE_PAY = 'google-pay',
   IDEAL = 'ideal',
   PAYPAL = 'paypal',
+  WECHAT_PAY = 'wechat-pay',
   WIRE_TRANSFER = 'wire-transfer',
   NONE = 'none',
 }

--- a/types/shared/shared.d.ts
+++ b/types/shared/shared.d.ts
@@ -18,7 +18,8 @@ export type AvailablePaymentMethod =
   | 'pix'
   | 'samsung_pay'
   | 'saved_payment_methods'
-  | 'upi';
+  | 'upi'
+  | 'wechat_pay';
 
 export type Variant = 'multi-page' | 'one-page';
 


### PR DESCRIPTION
## Summary

- Added `wechat_pay` to `AvailablePaymentMethod` type
- Added `WECHAT_PAY` to `CheckoutEventsPaymentMethodTypes` enum
- Bumps version to 1.6.2
