### PR TITLE
feat: add express variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 ### Added
 
-- Added `express` to the `DisplayMode` type for checkout settings.
+- Added `express` to the `Variant` type for checkout settings.
 
 ## 1.6.3-next.0 - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.6.4 - 2026-04-21
+
+### Added
+
+- Added `express` to the `DisplayMode` type for checkout settings.
+
 ## 1.6.3-next.0 - 2026-03-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.6.3-next.0",
+  "version": "1.6.4",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,7 @@ export {
   CheckoutEventUpsell,
 } from './checkout/events';
 
-export type DisplayMode = 'inline' | 'overlay';
+export type DisplayMode = 'inline' | 'overlay' | 'express';
 export type Environments = 'production' | 'sandbox';
 export type Version = 'classic' | 'v1';
 export type Theme = 'light' | 'dark';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,7 @@ export {
   CheckoutEventUpsell,
 } from './checkout/events';
 
-export type DisplayMode = 'inline' | 'overlay' | 'express';
+export type DisplayMode = 'inline' | 'overlay';
 export type Environments = 'production' | 'sandbox';
 export type Version = 'classic' | 'v1';
 export type Theme = 'light' | 'dark';

--- a/types/shared/shared.d.ts
+++ b/types/shared/shared.d.ts
@@ -21,7 +21,7 @@ export type AvailablePaymentMethod =
   | 'upi'
   | 'wechat_pay';
 
-export type Variant = 'multi-page' | 'one-page';
+export type Variant = 'multi-page' | 'one-page' | 'express';
 
 export type TaxMode = 'account_setting' | 'external' | 'internal';
 


### PR DESCRIPTION
- Adds `express` to `variant` settings
- Bump version to `1.6.4`