### PR TITLE
DX-1128: Add showNonExpressPaymentMethods to checkout settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-js-wrapper) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 1.6.5 - 2026-08-25
+
+### Added
+
+- Added `showNonExpressPaymentMethods` to checkout settings for express checkout.
+
 ## 1.6.4 - 2026-04-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-js",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Wrapper to load Paddle.js as a module and use TypeScript definitions when working with methods.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/types/checkout/checkout.d.ts
+++ b/types/checkout/checkout.d.ts
@@ -16,6 +16,7 @@ export interface CheckoutSettings {
   allowLogout?: boolean;
   showAddDiscounts?: boolean;
   showAddTaxId?: boolean;
+  showNonExpressPaymentMethods?: boolean;
   frameTarget?: string;
   frameStyle?: string;
   frameInitialHeight?: number;


### PR DESCRIPTION
## Summary
- Adds `showNonExpressPaymentMethods` to `CheckoutSettings` so TypeScript consumers of `@paddle/paddle-js` can pass the express checkout flag documented on [`Paddle.Checkout.open()`](https://developer.paddle.com/paddle-js/methods/paddle-checkout-open/).
- Bumps the package to `1.6.5` and records the change in the changelog.

This matches the Paddle.js v2 work in https://github.com/PaddleHQ/paddle-js-v2/pull/166. Default is `true` when `variant` is `express`; set `false` to hide “pay another way” and show only Apple Pay or Google Pay.

## Test plan
- [ ] Confirm `Checkout.open` / `Initialize` settings accept `showNonExpressPaymentMethods` without a TypeScript error
- [ ] Confirm other `CheckoutSettings` fields are unchanged
- [ ] After merge, publish `1.6.5` and verify consumers can set `{ variant: 'express', showNonExpressPaymentMethods: false }`